### PR TITLE
Use arguments to specify paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,3 @@ Please fork the repository and submit pull requests for your proposed changes.
 ## Contact
 
 For questions or support, please contact [yaonangu@u.nus.edu](mailto:your-email@example.com).
-```
-
-This updated README provides clear instructions on how to use the script, emphasizing the need to input absolute paths for the `.bib` files. This should help users understand how to properly set up and use the utility.

--- a/README.md
+++ b/README.md
@@ -26,25 +26,19 @@ cd BibTeXManager
 
 ## Usage
 
-Run the script by executing the following command in your terminal. You will be prompted to enter the absolute paths for your input and output
-
- `.bib` files:
+Run the script by executing the following command in your terminal.
 
 ```bash
-python bibtex_manager.py
+python bibtex_manager.py <input_file.bib> <output_file.bib>
 ```
 
-This command will process the specified BibTeX file, fetch missing DOIs, and save the updated entries to the output file.
+You need to specify the paths to your input and output files to execute the script:
 
-## Script Configuration
+1. **Input Path**: **the absolute path** of your old `.bib` file. This is the file that you want to update.
 
-Before running the script, you will need to set up the configuration by specifying the paths for your input and output files. Follow the steps below to configure the script:
+2. **Output Path**: **the absolute path** for the output `.bib` file where the updated version will be saved.
 
-1. **Input Path**: When prompted, enter **the absolute path** of your old `.bib` file. This is the file that you want to update.
-
-2. **Output Path**: Enter **the absolute path** for the output `.bib` file where the updated version will be saved.
-
-After entering these paths, the script will initialize a `BibTeXManager` with these paths and proceed to update the `.bib` file by fetching and updating DOI (Digital Object Identifier) information where applicable.
+The command will process the specified BibTeX file, fetch missing DOIs, and save the updated entries to the output file.
 
 ## Contributing
 

--- a/bibtex_manager.py
+++ b/bibtex_manager.py
@@ -7,9 +7,9 @@ Date: May 6th, 2024
 Version: 1.0
 
 Description:
-    BibTeXManager is a Python utility designed to enhance BibTeX files by adding missing
-    Digital Object Identifiers (DOIs) to the bibliography entries. It fetches DOIs using the
-    Crossref API and formats them as clickable URLs.
+    BibTeXManager is a Python utility designed to enhance BibTeX files by adding
+    missing Digital Object Identifiers (DOIs) to the bibliography entries. It
+    fetches DOIs using the Crossref API and formats them as clickable URLs.
 
 Copyright:
     Copyright (c) 2024, Yaonan Gu
@@ -17,21 +17,24 @@ Copyright:
 
     Redistribution and use in source and binary forms, with or without
     modification, are permitted provided that the following conditions are met:
-    
+
     - Redistributions of source code must retain the above copyright notice,
       this list of conditions and the following disclaimer.
-    
+
     - Redistributions in binary form must reproduce the above copyright notice,
       this list of conditions and the following disclaimer in the documentation
       and/or other materials provided with the distribution.
 """
 
 
-import requests
+from sys import stderr
+
 import bibtexparser
-from requests.exceptions import ChunkedEncodingError, RequestException, Timeout
+import requests
 from bibtexparser.bparser import BibTexParser
 from bibtexparser.customization import convert_to_unicode
+from requests.exceptions import ChunkedEncodingError, RequestException, Timeout
+
 
 class BibTeXManager:
     def __init__(self, bib_file, output_file):
@@ -50,50 +53,69 @@ class BibTeXManager:
 
     def fetch_doi(self, title, author, max_attempts=3):
         """Fetch DOI using Crossref API based on title and author with retries."""
-        query_params = {'query.title': title, 'query.author': author}
+        query_params = {"query.title": title, "query.author": author}
         timeout = self.initial_timeout
         for attempt in range(max_attempts):
             try:
                 response = requests.get(self.base_url, params=query_params, timeout=timeout)
                 response.raise_for_status()  # Raises HTTPError for bad responses
                 results = response.json()
-                items = results['message']['items']
+                items = results["message"]["items"]
                 if items:
-                    doi = items[0].get('DOI')
+                    doi = items[0].get("DOI")
                     return self.format_doi(doi)
             except Timeout:
-                print(f"Timeout occurred, attempt {attempt + 1} of {max_attempts}, increasing timeout...")
+                print(f"Timeout occurred, attempt {attempt + 1} of {max_attempts}, increasing timeout...", file=stderr)
                 timeout += 5  # Increase timeout by 5 seconds with each attempt
             except (ChunkedEncodingError, RequestException) as e:
-                print(f"Attempt {attempt + 1} of {max_attempts} failed: {e}")
+                print(f"Attempt {attempt + 1} of {max_attempts} failed: {e}", file=stderr)
                 if attempt == max_attempts - 1:
                     raise
             except Exception as e:
-                print(f"An error occurred: {e}")
+                print(f"An error occurred: {e}", file=stderr)
                 break
         return None
 
     def update_bibtex_doi(self):
         """Update the BibTeX file with DOIs."""
-        with open(self.bib_file, 'r') as bibtex_file:
+        with open(self.bib_file, "r") as bibtex_file:
             parser = BibTexParser(common_strings=True)
             parser.customization = convert_to_unicode
             bib_database = bibtexparser.load(bibtex_file)
 
         for entry in bib_database.entries:
-            if 'doi' not in entry:
-                doi = self.fetch_doi(entry.get('title', ''), entry.get('author', '').split(',')[0])
+            if "doi" not in entry:
+                doi = self.fetch_doi(entry.get("title", ""), entry.get("author", "").split(",")[0])
                 if doi:
-                    entry['doi'] = doi
-                    print(f"Added DOI for {entry['title']}: {doi}")
+                    entry["doi"] = doi
+                    print(f"Added DOI for {entry['title']}: {doi}", file=stderr)
 
-        with open(self.output_file, 'w') as bibtex_file:
+        with open(self.output_file, "w") as bibtex_file:
             bibtexparser.dump(bib_database, bibtex_file)
-        print("DOI update completed for BibTeX file.")
+        print("DOI update completed for BibTeX file.", file=stderr)
 
-# Test
+
 if __name__ == "__main__":
-    input_path = input("Please enter the absolute path of your old .bib file: ")
-    output_path = input("Please enter the absolute path for the output updated .bib file: ")
-    manager = BibTeXManager(input_path, output_path)
+    from argparse import ArgumentParser
+    from pathlib import Path
+
+    parser = ArgumentParser(description="Add missing DOIs to BibTeX files")
+    parser.add_argument("input", type=str, help="Path to the input .bib file")
+    parser.add_argument("output", type=str, help="Path to the output updated .bib file")
+    args = parser.parse_args()
+
+    file_input = Path("/dev/stdin")
+    file_output = Path("/dev/stdout")
+
+    if args.input != "-":
+        file_input = Path(args.input).resolve()
+        if not file_input.is_file():
+            raise FileNotFoundError(f"Input file {file_input} not found.")
+
+    if args.output != "-":
+        file_output = Path(args.output).resolve()
+        if file_output.exists() and not file_output.is_file():
+            raise ValueError(f"Output path {file_output} is not a file.")
+
+    manager = BibTeXManager(file_input, file_output)
     manager.update_bibtex_doi()


### PR DESCRIPTION
Now you can take advantage of shell auto-completion to easily input the path.

And can also use Unix pipe to run the command. For example, the following command will write the result to stdout.

```
python bibtex_manager.py <input> - 
```